### PR TITLE
Make it possible to embed as a library without unexpected os.Exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	_ "image/gif"
 	_ "image/jpeg"
 	_ "image/png"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/nomad-software/meme/cli"
@@ -15,6 +16,12 @@ import (
 func main() {
 	opt := cli.ParseOptions()
 
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintln(output.Stderr, color.RedString(r.(string)))
+			os.Exit(1)
+		}
+	}()
 	if opt.Help {
 		opt.PrintUsage()
 

--- a/output/output.go
+++ b/output/output.go
@@ -2,8 +2,6 @@ package output
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/fatih/color"
 	"github.com/mattn/go-colorable"
 )
@@ -19,15 +17,13 @@ var (
 // OnError prints an error if err is not nil and exits the program.
 func OnError(err error, text string) {
 	if err != nil {
-		fmt.Fprintln(Stderr, color.RedString(text+": %s", err.Error()))
-		os.Exit(1)
+		Error(fmt.Sprintf(text+": %s", err.Error()))
 	}
 }
 
 // Error prints an error and exits the program.
 func Error(text string) {
-	fmt.Fprintln(Stderr, color.RedString(text))
-	os.Exit(1)
+	panic(text)
 }
 
 // Info prints information.


### PR DESCRIPTION
Currently a couple of the functions in the `output` module do an explicit `os.Exit` after printing error messages, which makes it impossible to re-use this project as a library in other tools.  Making the lib properly embeddable with explicit error return values would be rather more complex, but this PR makes a minimal change to call `panic` instead of `os.Exit`, with the exit calls moved to a panic-recovery function in `main.go`.  Other tools can then implement their own panic recovery as appropriate.