### PR TITLE
feat: allow passing custom font

### DIFF
--- a/cli/options.go
+++ b/cli/options.go
@@ -60,7 +60,7 @@ func ParseOptions() Options {
 	flag.BoolVar(&opt.Shake, "shake", false, "Shake the image to intensify it. Always outputs a gif.\n")
 	flag.BoolVar(&opt.Trigger, "trigger", false, "Shake the image and add a triggered banner. Always outputs a gif.\n")
 	flag.BoolVar(&opt.ListTemplates, "list-templates", false, "List all of the built in templates.\n")
-	flag.StringVar(&opt.Font, "font", "", "Use a custom font.\n")
+	flag.StringVar(&opt.Font, "f", "", "The font to use for text rendering. Either a path to a ttf file or name of a font installed on your system.\n")
 	flag.Parse()
 
 	parsed := strings.Split(text, "|")

--- a/cli/options.go
+++ b/cli/options.go
@@ -42,6 +42,7 @@ type Options struct {
 	Top           string
 	Trigger       bool
 	ListTemplates bool
+	Font          string
 }
 
 // ParseOptions parses the command line options.
@@ -59,6 +60,7 @@ func ParseOptions() Options {
 	flag.BoolVar(&opt.Shake, "shake", false, "Shake the image to intensify it. Always outputs a gif.\n")
 	flag.BoolVar(&opt.Trigger, "trigger", false, "Shake the image and add a triggered banner. Always outputs a gif.\n")
 	flag.BoolVar(&opt.ListTemplates, "list-templates", false, "List all of the built in templates.\n")
+	flag.StringVar(&opt.Font, "font", "", "Use a custom font.\n")
 	flag.Parse()
 
 	parsed := strings.Split(text, "|")
@@ -130,5 +132,6 @@ func (opt *Options) PrintUsage() {
 	color.Cyan("    meme -i brace-yourselves -t \"Brace yourselves|The memes are coming!\"")
 	color.Cyan("    meme -i http://i.imgur.com/FsWetC0.jpg -t \"|China\"")
 	color.Cyan("    meme -i ~/Pictures/face.png -t \"Hello\"")
+	color.Cyan("    meme -i ~/Pictures/magic-carpet.png -t \"A whole new world...\" -font Arial")
 	fmt.Println("")
 }

--- a/font/font.go
+++ b/font/font.go
@@ -1,8 +1,11 @@
 package font
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/nomad-software/meme/data"
 	"github.com/nomad-software/meme/output"
@@ -13,8 +16,41 @@ var (
 	Path string
 )
 
+// SetPath overrides the font path at runtime. If the file exists it will be used directly.
+func SetPath(p string) error {
+	if p == "" {
+		return nil
+	}
+
+	// direct file
+	if _, err := os.Stat(p); err == nil {
+		Path = p
+		return nil
+	}
+
+	// try fc-match (Linux/macOS with fontconfig)
+	if fc, err := exec.LookPath("fc-match"); err == nil {
+		out, err := exec.Command(fc, "-f", "%{file}\\n", p).Output()
+		if err == nil {
+			f := strings.TrimSpace(string(out))
+			if f != "" {
+				if _, err := os.Stat(f); err == nil {
+					Path = f
+					return nil
+				}
+			}
+		}
+	}
+
+	return fmt.Errorf("font not found: %s", p)
+}
+
 // Write the embedded font to the temporary directory.
 func init() {
+	if Path != "" {
+		return
+	}
+
 	Path = filepath.Join(os.TempDir(), filepath.Base(data.Font))
 
 	if _, err := os.Stat(Path); os.IsNotExist(err) {

--- a/font/font.go
+++ b/font/font.go
@@ -16,16 +16,16 @@ var (
 	Path string
 )
 
-// SetPath overrides the font path at runtime. If the file exists it will be used directly.
-func SetPath(p string) error {
+// Override the font path at runtime.
+func SetPath(p string) {
 	if p == "" {
-		return nil
+		return
 	}
 
 	// direct file
 	if _, err := os.Stat(p); err == nil {
 		Path = p
-		return nil
+		return
 	}
 
 	// try fc-match (Linux/macOS with fontconfig)
@@ -36,13 +36,13 @@ func SetPath(p string) error {
 			if f != "" {
 				if _, err := os.Stat(f); err == nil {
 					Path = f
-					return nil
+					return
 				}
 			}
 		}
 	}
 
-	return fmt.Errorf("font not found: %s", p)
+	output.Error(fmt.Sprintf("Invalid font: %s", p))
 }
 
 // Write the embedded font to the temporary directory.

--- a/main.go
+++ b/main.go
@@ -16,13 +16,6 @@ import (
 func main() {
 	opt := cli.ParseOptions()
 
-	// If a font was supplied on the command line, try to use it.
-	if opt.Font != "" {
-		if err := font.SetPath(opt.Font); err != nil {
-			output.OnError(err, "Invalid font file")
-		}
-	}
-
 	if opt.Help {
 		opt.PrintUsage()
 
@@ -32,6 +25,8 @@ func main() {
 		}
 
 	} else if opt.Valid() {
+		font.SetPath(opt.Font)
+
 		st := image.Load(opt)
 		st = image.RenderImage(opt, st)
 

--- a/main.go
+++ b/main.go
@@ -8,12 +8,20 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/nomad-software/meme/cli"
+	"github.com/nomad-software/meme/font"
 	"github.com/nomad-software/meme/image"
 	"github.com/nomad-software/meme/output"
 )
 
 func main() {
 	opt := cli.ParseOptions()
+
+	// If a font was supplied on the command line, try to use it.
+	if opt.Font != "" {
+		if err := font.SetPath(opt.Font); err != nil {
+			output.OnError(err, "Invalid font file")
+		}
+	}
 
 	if opt.Help {
 		opt.PrintUsage()


### PR DESCRIPTION
This PR adds a `-f` option so you can use your own font when rendering memes

Accepts an absolute path, or does a font-config lookup (if you're on Linux or MacOS), so you can do e.g.

```
meme -f Arial
```
(as in the help text)

Tested manually

Fixes #19 